### PR TITLE
Use server to play audio when no storage permission was given

### DIFF
--- a/app/src/main/java/berlin/mfn/naturblick/ui/fieldbook/observation/ObservationViewFragment.kt
+++ b/app/src/main/java/berlin/mfn/naturblick/ui/fieldbook/observation/ObservationViewFragment.kt
@@ -150,7 +150,20 @@ class ObservationViewFragment : Fragment(), RequestedPermissionCallback {
                     if (granted == null) { // We didn't ask for permission
                         requestRead.checkPermission(requireContext(), this)
                         viewModel.startAudioOnPermissionResult()
+                    } else { // We do not have permission, use server
+                        lifecycleScope.launch {
+                            media.fetchUri(false, requireContext()).fold({ uri ->
+                                player.start(uri, start = start?.toLong(), end = end?.toLong())
+                            }, { error ->
+                                Toast.makeText(
+                                    requireContext(),
+                                    error.error,
+                                    Toast.LENGTH_LONG
+                                ).show()
+                            })
+                        }
                     }
+
                 })
             } else {
                 media.fetchUri(granted, requireContext()).fold({ uri ->


### PR DESCRIPTION
This fixes a bug that the app did not fetch the sound from the server when the user tried to play a sound which was not produced by the local app instance and the user did not allow the app to search in files. After this fix, it correctly downloads the sound from the server.