### PR TITLE
Wrap IOException related to file system in FileException

### DIFF
--- a/app/src/main/java/berlin/mfn/naturblick/ui/sound/Spectrogram.kt
+++ b/app/src/main/java/berlin/mfn/naturblick/ui/sound/Spectrogram.kt
@@ -22,13 +22,17 @@ object Spectrogram {
                         media.id,
                         context
                     )
-                    spectrogram.createNewFile()
-                    spectrogram.outputStream().use {
-                        it.write(bytes)
+                    NetworkResult.ioToFileException {
+                        spectrogram.createNewFile()
+                        spectrogram.outputStream().use {
+                            it.write(bytes)
+                        }
                     }
                 }
-                spectrogram.inputStream().use {
-                    BitmapFactory.decodeStream(it)
+                NetworkResult.ioToFileException {
+                    spectrogram.inputStream().use {
+                        BitmapFactory.decodeStream(it)
+                    }
                 }
             }
         }

--- a/app/src/main/java/berlin/mfn/naturblick/utils/FileException.kt
+++ b/app/src/main/java/berlin/mfn/naturblick/utils/FileException.kt
@@ -1,0 +1,7 @@
+package berlin.mfn.naturblick.utils
+
+class FileException: Exception {
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+    constructor(cause: Throwable) : super(cause)
+}

--- a/app/src/main/java/berlin/mfn/naturblick/utils/Media.kt
+++ b/app/src/main/java/berlin/mfn/naturblick/utils/Media.kt
@@ -212,7 +212,7 @@ sealed interface Media : Parcelable {
             }
             val uri =
                 resolver.insert(afterQContentUri(type), contentValues)
-                    ?: throw IOException("Failed to create MediaStore record for $name")
+                    ?: throw FileException("Failed to create MediaStore record for $name")
             return EmptyLocalMedia(type, id, uri)
         }
 

--- a/app/src/main/java/berlin/mfn/naturblick/utils/NetworkResult.kt
+++ b/app/src/main/java/berlin/mfn/naturblick/utils/NetworkResult.kt
@@ -101,5 +101,13 @@ data class NetworkResult<T : Any> internal constructor(
         }
 
         fun <T : Any> success(t: T): NetworkResult<T> = NetworkResult(t, null)
+
+        fun <T>ioToFileException(block: () -> T): T {
+            try {
+                return block()
+            } catch (ioe: IOException) {
+                throw FileException("IOException converted to FileException", ioe)
+            }
+        }
     }
 }


### PR DESCRIPTION
- IOExceptions are treated as "No network connection" in our network code, but sometimes IOExceptions can come from file system related operations.
- Wrap all relevant file system operations occuring as part of network operations